### PR TITLE
feat(deck): add Zustand navigation state with per-category progress tracking

### DIFF
--- a/src/stores/useDeckStore.js
+++ b/src/stores/useDeckStore.js
@@ -1,19 +1,123 @@
-//boilerplate
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
 const useDeckStore = create(
   persist(
-    (set) => ({
-      cards: [],
-      piles: { known: [], unknown: [] },
-      lastSynced: null,
-      moveCard: (cardId, pile) =>
-        set((state) => ({
-          piles: {
-            ...state.piles,
-            [pile]: [...state.piles[pile], cardId],
+    (set, get) => ({
+      // Ordered active queue - localStorage only, not synced to Supabase
+      queue: {},
+      // Card progress - persisted in localStorage and eventually Supabase
+      // {
+      //   [categoryId]: {
+      //     [cardId]: { status: 'active' | 'done', updatedAt: timestamp }
+      //   }
+      // }
+      progress: {},
+
+      // Initializes cards for a category, respecting already persisted state
+      setCards: (cards, categoryId) => set((state) => {
+        const existing = state.progress[categoryId] || {};
+
+        // Build progress respecting existing state
+        const updatedProgress = {};
+        cards.forEach((card) => {
+          updatedProgress[card.id] = existing[card.id] || {
+            status: 'active',
+            updatedAt: Date.now(),
+          };
+        });
+
+        // Build queue from cards not already done, preserving original order
+        const activeQueue = cards
+          .map(c => c.id)
+          .filter(id => updatedProgress[id].status === 'active');
+
+        return {
+          progress: {
+            ...state.progress,
+            [categoryId]: updatedProgress,
           },
-        })),
-      setDeck: (cards) => set({ cards, lastSynced: Date.now() }),
+          queue: {
+            ...state.queue,
+            [categoryId]: activeQueue,
+          }
+        };
+      }),
+
+      // Moves a card to done or back to end of active queue
+      moveCard: (cardId, target, categoryId) =>
+        set((state) => {
+          const currentQueue = state.queue[categoryId] || [];
+
+          // Update progress with new status and timestamp
+          const updatedProgress = {
+            ...state.progress[categoryId],
+            [cardId]: {
+              status: target,
+              updatedAt: Date.now(),
+            }
+          };
+
+          // Update queue - remove from current position, reinsert at end if active
+          const filteredQueue = currentQueue.filter(id => id !== cardId);
+          const updatedQueue = target === 'active'
+            ? [...filteredQueue, cardId]
+            : filteredQueue;
+
+          return {
+            progress: {
+              ...state.progress,
+              [categoryId]: updatedProgress,
+            },
+            queue: {
+              ...state.queue,
+              [categoryId]: updatedQueue,
+            }
+          };
+        }),
+
+      // Returns active card IDs in queue order for a category
+      getActive: (categoryId) => {
+        return get().queue[categoryId] || [];
+      },
+
+      // Returns done card IDs for a category
+      getDone: (categoryId) => {
+        const category = get().progress[categoryId] || {};
+        return Object.entries(category)
+          .filter(([_, card]) => card.status === 'done')
+          .map(([id]) => id);
+      },
+
+      // Explicitly resets all cards to active for a category - triggered by user restart
+      // Todo: add a button next to done to trigger this
+      resetDeck: (categoryId) => set((state) => {
+        const category = state.progress[categoryId] || {};
+
+        // Reset all statuses to active with fresh timestamp
+        const resetProgress = {};
+        Object.keys(category).forEach(cardId => {
+          resetProgress[cardId] = { status: 'active', updatedAt: Date.now() };
+        });
+
+        return {
+          progress: {
+            ...state.progress,
+            [categoryId]: resetProgress,
+          },
+          queue: {
+            ...state.queue,
+            [categoryId]: Object.keys(category),
+          }
+        };
+      }),
     }),
-    { name: 'deck' }
+    {
+      name: 'deck-progress',
+      // Only persist progress to localStorage, not the queue
+      partialize: (state) => ({ progress: state.progress }),
+    }
   )
 );
+
+export default useDeckStore;

--- a/src/views/deck/Deck.jsx
+++ b/src/views/deck/Deck.jsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router';
 import './deck.css';
 import Card from '../../components/card';
 import { getCards, getCategories } from '../../services/deckService';
+import useDeckStore from '../../stores/useDeckStore';
 
 export default function DeckView() {
   const [cards, setCards] = useState([]);
@@ -10,17 +11,36 @@ export default function DeckView() {
   const [searchParams] = useSearchParams();
   const selectedCategoryId = searchParams.get('subject');
   const cardRef = useRef(null);
-  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const { setCards: setStoreCards, moveCard, getActive, getDone, resetDeck } = useDeckStore();
+
+  // Ref to always have latest cards array available in event handlers
+  // Prevents stale closure issues with keyboard and swipe listeners
+  const cardsRef = useRef(cards);
+  useEffect(() => {
+    cardsRef.current = cards;
+  }, [cards]);
+
+  // Ref to always have latest selectedCategoryId available in event handlers
+  const categoryIdRef = useRef(selectedCategoryId);
+  useEffect(() => {
+    categoryIdRef.current = selectedCategoryId;
+  }, [selectedCategoryId]);
 
   // Handles card navigation and flip direction signals
-  // TODO: replace setCurrentIndex with Zustand moveCard in sub-issue 2
+  // Reads fresh from Zustand store to avoid stale closure issues
   function handleNext(direction) {
-  if (direction === 'flip') {
-    cardRef.current?.flip();
-    return;
+    if (direction === 'flip') {
+      cardRef.current?.flip();
+      return;
+    }
+    const freshActiveIds = getActive(categoryIdRef.current);
+    const currentCard = freshActiveIds
+      .map(id => cardsRef.current.find(c => c.id === id))
+      .filter(Boolean)[0];
+    if (!currentCard) return;
+    moveCard(currentCard.id, direction, categoryIdRef.current);
   }
-  setCurrentIndex(i => i + 1);
-}
 
   // Keyboard navigation - listens globally on window
   // Cleaned up on unmount to avoid memory leaks
@@ -35,68 +55,87 @@ export default function DeckView() {
   }, []);
 
   // Swipe detection - listens for touch events on the deck view
-useEffect(() => {
-  let touchStartX = 0;
-  let touchStartY = 0;
+  useEffect(() => {
+    let touchStartX = 0;
+    let touchStartY = 0;
 
-  function handleTouchStart(e) {
-    touchStartX = e.touches[0].clientX;
-    touchStartY = e.touches[0].clientY;
-  }
-
-  function handleTouchEnd(e) {
-    const deltaX = e.changedTouches[0].clientX - touchStartX;
-    const deltaY = e.changedTouches[0].clientY - touchStartY;
-    const absDeltaX = Math.abs(deltaX);
-    const absDeltaY = Math.abs(deltaY);
-
-    // Ignore if movement was too small
-    if (absDeltaX < 30 && absDeltaY < 30) return;
-
-   // Accept swipes from horizontal up to ~80 degrees
-   // stops only in the last 10 degrees before straight up
-   // 0.18 ≈ tan(10°) - the minimum horizontal-to-vertical ratio
-    if (absDeltaX > absDeltaY * 0.18) {
-      if (deltaX < 0) handleNext('done');
-      if (deltaX > 0) handleNext('active');
+    function handleTouchStart(e) {
+      touchStartX = e.touches[0].clientX;
+      touchStartY = e.touches[0].clientY;
     }
-  }
 
-  window.addEventListener('touchstart', handleTouchStart);
-  window.addEventListener('touchend', handleTouchEnd);
-  return () => {
-    window.removeEventListener('touchstart', handleTouchStart);
-    window.removeEventListener('touchend', handleTouchEnd);
-  };
-}, []);
+    function handleTouchEnd(e) {
+      const deltaX = e.changedTouches[0].clientX - touchStartX;
+      const deltaY = e.changedTouches[0].clientY - touchStartY;
+      const absDeltaX = Math.abs(deltaX);
+      const absDeltaY = Math.abs(deltaY);
+
+      // Ignore if movement was too small
+      if (absDeltaX < 30 && absDeltaY < 30) return;
+
+      // Accept swipes from horizontal up to ~80 degrees
+      // stops only in the last 10 degrees before straight up
+      // 0.18 ≈ tan(10°) - the minimum horizontal-to-vertical ratio
+      if (absDeltaX > absDeltaY * 0.18) {
+        if (deltaX < 0) handleNext('done');
+        if (deltaX > 0) handleNext('active');
+      }
+    }
+
+    window.addEventListener('touchstart', handleTouchStart);
+    window.addEventListener('touchend', handleTouchEnd);
+    return () => {
+      window.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, []);
 
   // Fetches cards and categories from Supabase on mount
+  // Initializes Zustand store with fetched cards for current category
   useEffect(() => {
     async function fetchData() {
-      const [cards, categories] = await Promise.all([
+      const [fetchedCards, fetchedCategories] = await Promise.all([
         getCards(),
         getCategories()
       ]);
-      setCards(cards);
-      setCategories(categories);
+      setCards(fetchedCards);
+      setCategories(fetchedCategories);
+      setStoreCards(
+        fetchedCards.filter(c => c.category_id === selectedCategoryId),
+        selectedCategoryId
+      );
     }
     fetchData();
-  }, []);
+  }, [selectedCategoryId]);
 
-  const categoryCards = cards.filter(c => c.category_id === selectedCategoryId);
-  const currentCard = categoryCards[currentIndex];
+  // Get current category's cards in active queue order
+  const activeIds = getActive(selectedCategoryId);
+  const doneIds = getDone(selectedCategoryId);
+  const categoryCards = activeIds
+    .map(id => cards.find(c => c.id === id))
+    .filter(Boolean);
+
+  const currentCard = categoryCards[0];
   const currentCategory = categories.find(c => c.id === currentCard?.category_id);
 
   // No cards loaded - bad connection or empty category
-if (!categoryCards.length) return <p>No cards available</p>;
+  if (!cards.length) return <p>No cards available</p>;
 
-// TODO: replace with completion screen in sub-issue 5
-if (!currentCard) return <p>No card found</p>;
+  // TODO: replace with completion screen in sub-issue 5
+  if (!currentCard) return (
+    <div>
+      <p>All cards completed!</p>
+      <button onClick={() => resetDeck(selectedCategoryId)}>Reset deck</button>
+    </div>
+  );
 
   return (
     <section className="deck-view">
-      <div className="deck-done">Done 10</div>
-      <div className="deck-active">Active 10</div>
+      {/* TODO: replace with deck visuals and counters in sub-issue 3 */}
+      {/* TODO: add reset button to trigger resetDeck (see useDeckStore) */}
+      <div className="deck-done">Done {doneIds.length}</div>
+      {/* TODO: replace with deck visuals and counters in sub-issue 3 */}
+      <div className="deck-active">Active {activeIds.length}</div>
       <div className="card-container">
         <Card
           ref={cardRef}


### PR DESCRIPTION
Sets up per-category card progress tracking using Zustand. Each card stores status and updatedAt for future Supabase sync. Queue handles session order, progress persists to localStorage between sessions.